### PR TITLE
Add Erlang Workshop to Open Source list

### DIFF
--- a/2023events.md
+++ b/2023events.md
@@ -162,6 +162,10 @@ How can you make the best out of these events or conferences?
 <details open>
  <summary><h2> September :sparkles: </h2></summary>
 
+- [Erlang Workshop](https://icfp24.sigplan.org/home/erlang-2024)
+
+  > Date: 2nd September || Mode: In-person || Location: Milan, Italy.
+
 - [PyCon Portugal](https://2023.pycon.pt/)
 
   > Date: 7th - 9th September || Mode: In-person || Location: Portugal.


### PR DESCRIPTION
Add conference Erlang Workshop, which serves as an exchange of ideas between academia and industry, focus on languages running on the BEAM virtual machine, such as Erlang, Elixir, or Gleam. All of these technologies are open source.