### PR TITLE
Add WordCamp Asia event for February 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,14 @@ If you are interested in contributing to this project, kindly read the [contribu
 - [SCALE22x](https://www.socallinuxexpo.org/scale/22x)
    > Date: 6th-9th March || Mode: In-person || Location: Pasadena - California.
 
-   - [FOSS Backstage Design](https://dev.events/conferences/foss-backstage-design-2025-vfrqahd3)
+- [FOSS Backstage Design](https://dev.events/conferences/foss-backstage-design-2025-vfrqahd3)
    > Date: 12th March || Mode: In-Person || Location: Berlin, Germany. 
   
 - [FOSSASIA Summit](https://summit.fossasia.org)
    > Date: 13th-15th March || Mode: In-person || Location: Bangkok - Thailand.
+
+- [WordCamp Asia](https://asia.wordcamp.org/2025)
+   > Date: 20th-22nd February || Mode: In-person || Location: Manila - Philippines.
 </details>
 
 


### PR DESCRIPTION
This PR adds details about the WordCamp Asia 2025, scheduled for 20th-22nd February 2025.