### PR TITLE
Add KCD Delhi to open-source-events readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ The calendar is automatically updated daily, ensuring you always have the latest
 - [CityJS New Delhi](https://india.cityjsconf.org/?utm_source=cityjs_homecard&utm_medium=card&utm_campaign=card_click)
   > Date: 18th - 19th February || Mode: In-person || Location: Shankar Lal Concert Hall, New Delhi, India.
 
+- [Kubernetes Community Days Delhi](https://www.kcddelhi.com/)
+  > Date: 21st February || Mode: In-person || Location: New Delhi, India
+
 - [LF Member Summit](https://events.linuxfoundation.org/lf-member-summit/)
   > Date: 24th - 25th February || Mode: In-person || Location: Napa, California, USA.
 


### PR DESCRIPTION
KCD New Delhi is an official Cloud Native Computing Foundation event.
Website: https://www.kcddelhi.com/
LinkedIn: https://in.linkedin.com/company/kcddelhi
X: https://x.com/kcddelhi
Instagram: https://www.instagram.com/kcddelhi/
CNCF website: https://www.cncf.io/blog/2025/09/26/announcing-h1-2026-kcds/ <br/>
<img width="574" height="311" alt="image" src="https://github.com/user-attachments/assets/4ac23f7e-eff1-45b7-be89-e3e1711b5847" />
