### PR TITLE
Add PyCon Greece 2026 event details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ The calendar is automatically updated daily, ensuring you always have the latest
 - [Open Source Summit Europe](https://events.linuxfoundation.org/open-source-summit-europe/)
    > Date: 7th - 9th October || Mode: In-person || Location: Prague, Czechia.
    
-- [Embedded Linux Conference Euuope](https://events.linuxfoundation.org/embedded-linux-conference-europe/)
+- [Embedded Linux Conference Europe](https://events.linuxfoundation.org/embedded-linux-conference-europe/)
    > Date: 7th - 9th October || Mode: In-person || Location: Prague, Czechia.
 
 - [PyCon Greece 2026](https://2026.pycon.gr/)


### PR DESCRIPTION
The PR adds PyCon Greece 2026 to the events list for 2026. PyCon Greece is a purely Open Source / Community-Driven event, ran entirely by volunteers from the Greek Python Community.